### PR TITLE
[FEATURE]: Implement batch processing of sites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sqlite3', '1.3.13'
 gem 'uglifier', '4.1.6'
 gem 'webpacker', '3.2.2'
 gem 'will_paginate', '3.1.6'
+gem 'delayed_job_active_record', '~> 4.1'
 
 group :development, :test do
   gem 'byebug', '10.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'bootsnap', '1.1.8', require: false
+gem 'delayed_job_active_record', '~> 4.1'
 gem 'haml', '5.0.4'
 gem 'jbuilder', '2.7.0'
 gem 'parser', '2.3.3.1'
@@ -10,7 +11,6 @@ gem 'sqlite3', '1.3.13'
 gem 'uglifier', '4.1.6'
 gem 'webpacker', '3.2.2'
 gem 'will_paginate', '3.1.6'
-gem 'delayed_job_active_record', '~> 4.1'
 
 group :development, :test do
   gem 'byebug', '10.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,11 @@ GEM
     byebug (10.0.0)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
+    delayed_job (4.1.4)
+      activesupport (>= 3.0, < 5.2)
+    delayed_job_active_record (4.1.2)
+      activerecord (>= 3.0, < 5.2)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     erubi (1.7.0)
     execjs (2.7.0)
@@ -216,6 +221,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (= 1.1.8)
   byebug (= 10.0.0)
+  delayed_job_active_record (~> 4.1)
   haml (= 5.0.4)
   haml_lint (= 0.25.1)
   jbuilder (= 2.7.0)
@@ -235,4 +241,4 @@ DEPENDENCIES
   will_paginate (= 3.1.6)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/README.rdoc
+++ b/README.rdoc
@@ -56,7 +56,27 @@ You'll receive the id of the `SiteBatch` object:
   }
 
 If you want to check the status of your batch, use that id like:
-TODO
+
+  curl -X GET -H "Accept: application/json" http://admin:admin@localhost:3000/site_batches/2
+
+You'll get a response that includes sites that have been generated for the batch:
+
+  {
+    "site_batch": {
+      "id": 2,
+      "status": "completed",
+      "submitted_urls": ["https://google.com","https://yahoo.com"],
+      "sites": [
+        {
+          "id": 2,
+          "status": "succeeded",
+          "image": {
+            "url": ".../1.png"
+          }
+        }
+      ]
+    }
+  }
 
 == Author
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -43,9 +43,9 @@ You can submit multiple urls to be processed as a batch.
 
   curl -X POST -d '{"site_batch": {"submitted_urls": ["https://google.com","https://yahoo.com"]}}' -H "Content-Type: application/json" http://admin:admin@localhost:3000/site_batches
 
-All valid urls will be processed in a background job.
+All valid urls will be processed in a background job (remember to start delayed job on your machine).
 Invalid urls will not be processed, but will not cause the entire batch to fail.
-You'll receive the id of the `SiteBatch` object:
+You'll receive the id of the site batch object:
 
   {
     "site_batch": {

--- a/README.rdoc
+++ b/README.rdoc
@@ -19,6 +19,8 @@ And visit http://localhost:3000
 
 == How it works
 
+=== Processing one site instantly
+
 Send a POST request like below. Use basic http authorization and provide a parameter named +site[url]+. You can test it with curl:
 
   curl -X POST -d "site[url]=https://google.com" -H "Accept: application/json" http://admin:admin@localhost:3000/sites
@@ -34,6 +36,27 @@ On a valid url, you'll get a json response like this:
       }
     }
   }
+
+=== Batch Processing multiple sites
+
+You can submit multiple urls to be processed as a batch.
+
+  curl -X POST -d '{"site_batch": {"submitted_urls": ["https://google.com","https://yahoo.com"]}}' -H "Content-Type: application/json" http://admin:admin@localhost:3000/site_batches
+
+All valid urls will be processed in a background job.
+Invalid urls will not be processed, but will not cause the entire batch to fail.
+You'll receive the id of the `SiteBatch` object:
+
+  {
+    "site_batch": {
+      "id": 2
+      "status": "pending",
+      "submitted_urls": ["https://google.com","https://yahoo.com"]
+    }
+  }
+
+If you want to check the status of your batch, use that id like:
+TODO
 
 == Author
 

--- a/app/assets/stylesheets/site_batches.scss
+++ b/app/assets/stylesheets/site_batches.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the SiteBatches controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/site_batches.scss
+++ b/app/assets/stylesheets/site_batches.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the SiteBatches controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/site_batches_controller.rb
+++ b/app/controllers/site_batches_controller.rb
@@ -1,0 +1,17 @@
+class SiteBatchesController < ApplicationController
+  before_action :user_required
+
+  def create
+    @site_batch = SiteBatch.new(site_batch_params.merge(user: @current_user))
+    @site_batch.save
+    respond_to do |format|
+      format.json
+    end
+  end
+
+  private
+
+  def site_batch_params
+    params.require(:site_batch).permit(:submitted_urls => [])
+  end
+end

--- a/app/controllers/site_batches_controller.rb
+++ b/app/controllers/site_batches_controller.rb
@@ -2,14 +2,16 @@ class SiteBatchesController < ApplicationController
   before_action :user_required
 
   def show
-    @site_batch = SiteBatch.find(params[:id])
-
-    respond_to { |format| format.json }
+    @site_batch = @current_user.site_batches.find_by(id: params[:id])
+    if @site_batch.present?
+      respond_to { |format| format.json }
+    else
+      render json: {errors: 'not found'}, status: 404
+    end
   end
 
   def create
-    @site_batch = SiteBatch.new(site_batch_params.merge(user: @current_user))
-    @site_batch.save
+    @site_batch = @current_user.site_batches.create(site_batch_params)
 
     respond_to { |format| format.json }
   end
@@ -17,6 +19,6 @@ class SiteBatchesController < ApplicationController
   private
 
   def site_batch_params
-    params.require(:site_batch).permit(:submitted_urls => [])
+    params.require(:site_batch).permit(submitted_urls: [])
   end
 end

--- a/app/controllers/site_batches_controller.rb
+++ b/app/controllers/site_batches_controller.rb
@@ -1,12 +1,17 @@
 class SiteBatchesController < ApplicationController
   before_action :user_required
 
+  def show
+    @site_batch = SiteBatch.find(params[:id])
+
+    respond_to { |format| format.json }
+  end
+
   def create
     @site_batch = SiteBatch.new(site_batch_params.merge(user: @current_user))
     @site_batch.save
-    respond_to do |format|
-      format.json
-    end
+
+    respond_to { |format| format.json }
   end
 
   private

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -14,5 +14,4 @@ class SitesController < ApplicationController
       format.json
     end
   end
-
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -8,10 +8,11 @@ class SitesController < ApplicationController
 
   def create
     @site = @current_user.sites.build params.fetch(:site, {}).permit(:url)
-    @site.process! if @site.save
+    @site.save
     respond_to do |format|
       format.html { redirect_to sites_url }
       format.json
     end
   end
+
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -8,7 +8,7 @@ class SitesController < ApplicationController
 
   def create
     @site = @current_user.sites.build params.fetch(:site, {}).permit(:url)
-    @site.save
+    @site.process! if @site.save
     respond_to do |format|
       format.html { redirect_to sites_url }
       format.json

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -2,7 +2,7 @@ class SitesController < ApplicationController
   before_action :user_required
 
   def index
-    @sites = Site.order(created_at: :desc).page params[:page]
+    @sites = Site.order(created_at: :desc).includes(:user).page params[:page]
     @site  = Site.new
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,7 @@
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/site_batch_job.rb
+++ b/app/jobs/site_batch_job.rb
@@ -1,0 +1,22 @@
+class SiteBatchJob < ApplicationJob
+  queue_as :default
+
+  def perform(site_batch_id)
+    @site_batch = SiteBatch.find(site_batch_id)
+    @site_batch.started!
+    process_sites
+    @site_batch.completed!
+  end
+
+  private
+
+  def process_sites
+    @site_batch.submitted_urls.each do |url|
+      begin
+        Site.create(user: @site_batch.user, url: url, site_batch: @site_batch).process!
+      rescue
+        next
+      end
+    end
+  end
+end

--- a/app/jobs/site_batch_job.rb
+++ b/app/jobs/site_batch_job.rb
@@ -13,8 +13,8 @@ class SiteBatchJob < ApplicationJob
   def process_sites
     @site_batch.submitted_urls.each do |url|
       begin
-        Site.create(user: @site_batch.user, url: url, site_batch: @site_batch).process!
-      rescue
+        Site.create(user: @site_batch.user, url: url, site_batch: @site_batch)
+      rescue StandardError
         next
       end
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -7,6 +7,7 @@ class Site < ApplicationRecord
 
   has_one_attached :image
 
+  after_create :process!
   def process!
     started!
     handle generate_png

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -6,7 +6,6 @@ class Site < ApplicationRecord
 
   has_one_attached :image
 
-  after_create :process!
   def process!
     started!
     handle generate_png

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,6 +3,7 @@ class Site < ApplicationRecord
   enum status: %i[submitted started succeeded failed]
 
   belongs_to :user, counter_cache: true
+  belongs_to :site_batch, optional: true
 
   has_one_attached :image
 

--- a/app/models/site_batch.rb
+++ b/app/models/site_batch.rb
@@ -1,0 +1,8 @@
+class SiteBatch < ApplicationRecord
+  belongs_to :user
+  has_many :sites
+
+  enum status: %i[pending started completed]
+
+  validates_presence_of :user_id
+end

--- a/app/models/site_batch.rb
+++ b/app/models/site_batch.rb
@@ -5,15 +5,15 @@ class SiteBatch < ApplicationRecord
   enum status: %i[pending started completed]
   serialize :submitted_urls, Array
 
-  validates_presence_of :user_id, :submitted_urls, :status
+  validates_presence_of :user_id, :submitted_urls
 
-  after_initialize :pending!
+  after_create :pending!
   after_create :queue_batch_job
 
 
   private
 
   def queue_batch_job
-
+    SiteBatchJob.perform_later self.id
   end
 end

--- a/app/models/site_batch.rb
+++ b/app/models/site_batch.rb
@@ -1,19 +1,24 @@
 class SiteBatch < ApplicationRecord
   belongs_to :user
-  has_many :sites
+  has_many :sites, dependent: :nullify
 
   enum status: %i[pending started completed]
   serialize :submitted_urls, Array
 
-  validates_presence_of :user_id, :submitted_urls
-
   after_create :pending!
   after_create :queue_batch_job
-
 
   private
 
   def queue_batch_job
     SiteBatchJob.perform_later self.id
   end
+
+  def no_blank_urls
+    return if submitted_urls.all?(&:present?)
+    errors.add(:submitted_urls, "can't be blank")
+  end
+
+  validates_presence_of :user_id, :submitted_urls
+  validate :no_blank_urls
 end

--- a/app/models/site_batch.rb
+++ b/app/models/site_batch.rb
@@ -3,6 +3,17 @@ class SiteBatch < ApplicationRecord
   has_many :sites
 
   enum status: %i[pending started completed]
+  serialize :submitted_urls, Array
 
-  validates_presence_of :user_id
+  validates_presence_of :user_id, :submitted_urls, :status
+
+  after_initialize :pending!
+  after_create :queue_batch_job
+
+
+  private
+
+  def queue_batch_job
+
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   end
 
   has_many :sites, dependent: :destroy
+  has_many :site_batches, dependent: :destroy
 
   scope :by_name, ->{ order(name: :asc) }
 

--- a/app/views/site_batches/create.json.jbuilder
+++ b/app/views/site_batches/create.json.jbuilder
@@ -1,0 +1,9 @@
+json.site_batch do
+  if @site_batch.persisted?
+    json.id @site_batch.id
+    json.status @site_batch.status
+    json.submitted_urls @site_batch.submitted_urls
+  else
+    json.errors @site_batch.errors
+  end
+end

--- a/app/views/site_batches/show.json.jbuilder
+++ b/app/views/site_batches/show.json.jbuilder
@@ -1,0 +1,6 @@
+json.site_batch do
+  json.id @site_batch.id
+  json.status @site_batch.status
+  json.submitted_urls @site_batch.submitted_urls
+  json.sites @site_batch.sites, partial: 'sites/site', as: :site
+end

--- a/app/views/sites/_site.json.jbuilder
+++ b/app/views/sites/_site.json.jbuilder
@@ -1,0 +1,8 @@
+json.id site.id
+json.status site.status
+
+if site.image.attached?
+  json.image do
+    json.url url_for(site.image)
+  end
+end

--- a/app/views/sites/create.json.jbuilder
+++ b/app/views/sites/create.json.jbuilder
@@ -1,14 +1,6 @@
 json.site do
   if @site.persisted?
-    json.id @site.id
-    json.status @site.status
-
-    if @site.image.attached?
-      json.image do
-        json.url url_for(@site.image)
-      end
-    end
-
+    json.partial! 'sites/site', site: @site
   else
     json.errors @site.errors
   end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Portrait
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.active_job.queue_adapter = :delayed_job
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Portrait::Application.routes.draw do
   resources :sites
   resources :users
+  resources :site_batches, only: %i(create show)
 
   root to: 'home#index'
 end

--- a/db/migrate/20180301030302_create_site_batches.rb
+++ b/db/migrate/20180301030302_create_site_batches.rb
@@ -1,0 +1,16 @@
+class CreateSiteBatches < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :site_batches do |t|
+      t.references :user, index: true
+      t.integer :status
+      t.timestamps
+    end
+
+    add_column :sites, :site_batch_id, :integer, index: true
+  end
+
+  def self.down
+    drop_table :site_batches
+    remove_column :sites, :site_batch_id
+  end
+end

--- a/db/migrate/20180301030302_create_site_batches.rb
+++ b/db/migrate/20180301030302_create_site_batches.rb
@@ -3,6 +3,7 @@ class CreateSiteBatches < ActiveRecord::Migration[5.2]
     create_table :site_batches do |t|
       t.references :user, index: true
       t.integer :status
+      t.text :submitted_urls
       t.timestamps
     end
 

--- a/db/migrate/20180302040627_create_delayed_jobs.rb
+++ b/db/migrate/20180302040627_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_03_01_030302) do
+ActiveRecord::Schema.define(version: 2018_03_02_040627) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -33,9 +33,25 @@ ActiveRecord::Schema.define(version: 2018_03_01_030302) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
   create_table "site_batches", force: :cascade do |t|
     t.integer "user_id"
     t.integer "status"
+    t.text "submitted_urls"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_site_batches_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_02_17_000130) do
+ActiveRecord::Schema.define(version: 2018_03_01_030302) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -33,12 +33,21 @@ ActiveRecord::Schema.define(version: 2018_02_17_000130) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "site_batches", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_site_batches_on_user_id"
+  end
+
   create_table "sites", force: :cascade do |t|
     t.string "url"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "user_id"
     t.integer "status"
+    t.integer "site_batch_id"
     t.index ["created_at"], name: "index_sites_on_created_at"
     t.index ["status"], name: "index_sites_on_status"
     t.index ["user_id"], name: "index_sites_on_user_id"

--- a/spec/fixtures/site_batches.yml
+++ b/spec/fixtures/site_batches.yml
@@ -1,0 +1,12 @@
+site_batch_valid_sites:
+  user: admin
+  status: <%= SiteBatch.statuses[:pending] %>
+  submitted_urls:
+    - https://google.com
+    - https://yahoo.com
+site_batch_with_invalid_site:
+  user: admin
+  status: <%= SiteBatch.statuses[:pending] %>
+  submitted_urls:
+    - https://google.com
+    - yahoo

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,3 +1,6 @@
 admin:
   name: admin
   password: password
+user:
+  name: user
+  password: password

--- a/spec/jobs/site_batch_job_spec.rb
+++ b/spec/jobs/site_batch_job_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe SiteBatchJob, type: :job do
+  context 'with an invalid url' do
+    it 'still process valid urls' do
+      site_batch = site_batches(:site_batch_with_invalid_site)
+      SiteBatchJob.perform_now site_batch.id
+      expect(site_batch.reload.status).to eq('completed')
+      expect(site_batch.sites.pluck(:status).sort).to eq(['succeeded'])
+    end
+  end
+
+  context 'with all valid urls' do
+    it 'processes all urls' do
+      site_batch = site_batches(:site_batch_valid_sites)
+      SiteBatchJob.perform_now site_batch.id
+      expect(site_batch.reload.status).to eq('completed')
+      expect(site_batch.sites.pluck(:status).sort).to eq(['succeeded']*2)
+    end
+  end
+end

--- a/spec/jobs/site_batch_job_spec.rb
+++ b/spec/jobs/site_batch_job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SiteBatchJob, type: :job do
   context 'with an invalid url' do
-    it 'still process valid urls' do
+    it 'still processes valid urls' do
       site_batch = site_batches(:site_batch_with_invalid_site)
       SiteBatchJob.perform_now site_batch.id
       expect(site_batch.reload.status).to eq('completed')

--- a/spec/models/site_batch_spec.rb
+++ b/spec/models/site_batch_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe SiteBatch, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/site_batch_spec.rb
+++ b/spec/models/site_batch_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SiteBatch, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/site_batches_controller_spec.rb
+++ b/spec/requests/site_batches_controller_spec.rb
@@ -25,5 +25,20 @@ RSpec.describe SiteBatchesController, type: :request do
         expect(JSON.parse(response.body)['site_batch']).to include('id')
       end
     end
+
+    context 'to #show with GET' do
+      before do
+        @site_batch = site_batches(:site_batch_with_invalid_site)
+        @site_batch.sites << sites(:google)
+      end
+
+      it 'returns the site batch and generated sites' do
+        gt @site_batch, format: :json
+        expect(response).to be_successful
+        site_batch_json = JSON.parse(response.body)
+        expect(site_batch_json['site_batch']).to include('sites')
+        expect(site_batch_json['site_batch']).to include('id')
+      end
+    end
   end
 end

--- a/spec/requests/site_batches_controller_spec.rb
+++ b/spec/requests/site_batches_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe SiteBatchesController, type: :request do
+  before { login_as :admin }
+
+  context 'for json requests' do
+    it 'creates a new SiteBatch for POST to #create' do
+      expect{
+        pst :site_batches, site_batch: { submitted_urls: ['https://www.google.com'] }, format: :json
+      }.to change(SiteBatch, :count).by(1)
+    end
+
+    it 'creates a job for each url submitted' do
+      expect{
+        pst :site_batches, site_batch: { submitted_urls: ['https://www.google.com', 'https://www.yahoo.com'] }, format: :json
+      }.to change(Delayed::Job, :count).by(2)
+    end
+  end
+end

--- a/spec/requests/site_batches_controller_spec.rb
+++ b/spec/requests/site_batches_controller_spec.rb
@@ -4,16 +4,26 @@ RSpec.describe SiteBatchesController, type: :request do
   before { login_as :admin }
 
   context 'for json requests' do
-    it 'creates a new SiteBatch for POST to #create' do
-      expect{
-        pst :site_batches, site_batch: { submitted_urls: ['https://www.google.com'] }, format: :json
-      }.to change(SiteBatch, :count).by(1)
-    end
+    context 'to #create with POST' do
+      it 'creates a new SiteBatch' do
+        expect{
+          pst :site_batches, site_batch: { submitted_urls: ['https://www.google.com'] }, format: :json
+          expect(response).to be_successful
+        }.to change(SiteBatch, :count).by(1)
+      end
 
-    it 'creates a job for each url submitted' do
-      expect{
-        pst :site_batches, site_batch: { submitted_urls: ['https://www.google.com', 'https://www.yahoo.com'] }, format: :json
-      }.to change(Delayed::Job, :count).by(2)
+      it 'creates a job to process the site batch' do
+        expect{
+          pst :site_batches, site_batch: { submitted_urls: ['https://www.google.com', 'https://www.yahoo.com'] }, format: :json
+          expect(response).to be_successful
+        }.to change(Delayed::Job, :count).by(1)
+      end
+
+      it 'returns the SiteBatch id and status' do
+        pst :site_batches, site_batch: { submitted_urls: ['https://www.google.com'] }, format: :json
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)['site_batch']).to include('id')
+      end
     end
   end
 end


### PR DESCRIPTION
### Feature description
For this feature, I decided to try and cap time spent at ~8 hours or so. I ended up in that ballpark with  scoping/planning, coding, cleanup, and documentation (spread out over a couple days). 

This PR adds batch processing to Portrait (new delayed job dependency), such that a consumer can request snapshots of many different urls, have them processed in the background, and then retrieve them later as a group. This feature is API-only in the spirit of Portrait being "primarily designed to be used as a service".

### Use cases
Aside from some of the obvious reasons for backgrounding, one of the main use cases I had in mind would be for something like a multi-page resource (i.e. multi-page survey preview? Or a metric dashboard spanning multiple urls?). The consumer could then stitch them together either in their own UI or as a single image via processing (perhaps Portrait could even stitch the batch together in the future and return a collage). 

### Improvements
The next improvements I'd make to this feature would probably be:
* Add some additional error handling feedback for consumers. Specifically, it would be nice for them to know which url's were invalid (if any). Right now it's possible to do that by diffing what you submitted vs. the site records that are returned when querying the site batch, but an improved API could provide that information explicitly when retrieving a batch.
* Add some ordering to the submitted urls. Some multi-page resources are likely ordered, so it would be nice to be able to allow a consumer to specify an order to their sites when creating a batch via API, and preserve that order for the consumer to reflect on once the batch is done.